### PR TITLE
Fixed social media links layout when hover

### DIFF
--- a/public/css/wollok.css
+++ b/public/css/wollok.css
@@ -66,6 +66,7 @@
     overflow:hidden;
     margin:0; padding:0;
     list-style:none;
+    padding-top: 5px;
 }
 
 .soc li {


### PR DESCRIPTION
It's my first time doing a pull request. I'm sorry if I'm doing something wrong.

I realized that the social media links were being cut when they were on hover.
I just added one line in the styles fixing it.