### PR TITLE
Falta agregar en el mixin Flying el método abstracto reduceEnergy

### DIFF
--- a/documentacion/conceptos/avanzados.md
+++ b/documentacion/conceptos/avanzados.md
@@ -124,6 +124,7 @@ mixin Flying {
     fliedMeters = fliedMeters + meters
   }
   method fliedMeters() = fliedMeters
+  method reduceEnergy(amount)
 }
 ```
 


### PR DESCRIPTION
Para lograr compilar los 3 ejemplos de conceptos avanzados en la sección Mixins abstractos. es necesario que el mixin Flying declare el método abstracto  reduceEnergy(amount).

